### PR TITLE
Column reversed for only mobile

### DIFF
--- a/Resources/views/edit.blade.php
+++ b/Resources/views/edit.blade.php
@@ -3,7 +3,7 @@
 
     <x-slot name="content">
         <x-show.container>
-            <x-show.content>
+            <x-show.content class="flex flex-col-reverse lg:flex-row mt-5 sm:mt-12 gap-y-4" override="class">
                 <x-show.content.left>
                     <x-form id="offline-payment" method="POST" route="offline-payments.settings.update">
                         <x-form.section>


### PR DESCRIPTION
Left and right columns reversed. Because submit button didn’t appear.

<img width="243" alt="Screen Shot 2022-11-09 at 10 48 55" src="https://user-images.githubusercontent.com/22003497/200770340-eb7f0901-601a-4591-a785-be41fdda4435.png">
